### PR TITLE
Change default branch from 'main' to 'master'

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint check with Ruff
 on:
   pull_request:
     branches:
-    - main
+    - master
   workflow_dispatch:
 
 jobs:
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - "3.12"
         - "3.13"
         
     steps:


### PR DESCRIPTION
Change default branch from 'main' to 'master' and change to pytthon version 3.13 only