### PR TITLE
QS: Dockerfile not accepting args fix

### DIFF
--- a/qns-svc/entrypoint.sh
+++ b/qns-svc/entrypoint.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-/app/.venv/bin/aerich upgrade && /app/.venv/bin/fastapi run /app/routes.py
+/app/.venv/bin/aerich upgrade && exec /app/.venv/bin/fastapi run /app/routes.py $@


### PR DESCRIPTION
This PR fixes an issue where cli arguments are not passed to the underlying fastapi executable when running under docker.