### PR TITLE
Support for python environment in monorepo

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,30 @@
 {
-    "files.insertFinalNewline": true
+    "files.insertFinalNewline": true,
+    "python-envs.pythonProjects": [
+        {
+            "path": "api-gateway",
+            "envManager": "ms-python.python:venv",
+            "packageManager": "ms-python.python:pip"
+        },
+        {
+            "path": "matching-svc",
+            "envManager": "ms-python.python:venv",
+            "packageManager": "ms-python.python:pip"
+        },
+        {
+            "path": "qns-svc",
+            "envManager": "ms-python.python:venv",
+            "packageManager": "ms-python.python:pip"
+        },
+        {
+            "path": "support/qns-svc-import",
+            "envManager": "ms-python.python:venv",
+            "packageManager": "ms-python.python:pip"
+        },
+        {
+            "path": "user-svc",
+            "envManager": "ms-python.python:venv",
+            "packageManager": "ms-python.python:pip"
+        }
+    ]
 }


### PR DESCRIPTION
This PR add development QOL support where each python environment can be discovered by vscode using the Python Environments extension: https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs