### PR TITLE
Implement round-robin load balancing for service instance selection

### DIFF
--- a/api-gateway/.env.template
+++ b/api-gateway/.env.template
@@ -42,6 +42,8 @@ USER_SERVICE_LOGIN_PATH="/us/auth/login"
 # Each microservice must periodically refresh its registration within this interval,
 # or the API Gateway will consider the instance dead and remove it.
 HEARTBEAT_TTL=300
+# Time-to-live (TTL) in seconds for the round-robin counter used in load balancing.
+RR_TTL=3600
 
 
 # ============================================================================

--- a/api-gateway/controllers/gateway_controller.py
+++ b/api-gateway/controllers/gateway_controller.py
@@ -22,10 +22,11 @@ class GatewayController:
         redis: aioredis.Redis,
         token_ttl_seconds: int = int(DEFAULT_COOKIE_MAX_AGE),
         heartbeat_ttl: int = 30,
+        rr_ttl: int = 3600,
     ):
         self.redis = redis
         self.ttl = token_ttl_seconds
-        self.registry = ServiceRegistry(redis, heartbeat_ttl=heartbeat_ttl)
+        self.registry = ServiceRegistry(redis, heartbeat_ttl=heartbeat_ttl, rr_ttl=rr_ttl)
 
     async def _find_existing_token_key(self, user_id: str) -> str | None:
         """Scans for an existing access token key associated with a user ID.

--- a/api-gateway/service/redis_settings.py
+++ b/api-gateway/service/redis_settings.py
@@ -12,6 +12,7 @@ REDIS_URL = get_envvar("REDIS_URL")
 TOKEN_EXPIRE_HOURS = int(get_envvar("TOKEN_EXPIRE_HOURS"))
 TOKEN_EXPIRE_SECONDS = int(TOKEN_EXPIRE_HOURS * 3600)
 HEARTBEAT_TTL = int(get_envvar("HEARTBEAT_TTL"))
+RR_TTL = int(get_envvar("RR_TTL"))
 
 # Singletons bound during app lifespan
 _redis: aioredis.Redis
@@ -48,4 +49,5 @@ async def get_gateway(
         redis=redis,
         token_ttl_seconds=TOKEN_EXPIRE_SECONDS,
         heartbeat_ttl=HEARTBEAT_TTL,
+        rr_ttl=RR_TTL,
     )


### PR DESCRIPTION
Closes #133 

This PR implements proper load balancing for selection of service instance when forwarding a request. Prior to this, the gateway always selected the first available instance on the list.